### PR TITLE
chore: Adds title to demo

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,9 +1,24 @@
 <template>
   <main>
     <div class="intro">
-      <p>Hi 👋! This template gives you a <a href="https://nuxtjs.org/">Nuxt</a> app with the scaffolding for <a href="https://www.netlify.com/products/functions/">Netlify Functions</a>, <a href="https://www.netlify.com/products/forms/">Forms</a>, and <a href="https://docs.netlify.com/routing/redirects/">Redirects</a>. Our aim was to give you the code you would need to hit the ground running with a few fun features.</p>
+      <h1>Nuxt Toolbox</h1>
+      <p>
+        Hi 👋! This template gives you a
+        <a href="https://nuxtjs.org/">Nuxt</a> app with the scaffolding for
+        <a href="https://www.netlify.com/products/functions/"
+          >Netlify Functions</a
+        >, <a href="https://www.netlify.com/products/forms/">Forms</a>, and
+        <a href="https://docs.netlify.com/routing/redirects/">Redirects</a>. Our
+        aim was to give you the code you would need to hit the ground running
+        with a few fun features.
+      </p>
 
-      <p>You can find the code for this project on GitHub at <a href="https://github.com/netlify-templates/nuxt-toolbox">https://github.com/netlify-templates/nuxt-toolbox</a>! Happy coding!</p>
+      <p>
+        You can find the code for this project on GitHub at
+        <a href="https://github.com/netlify-templates/nuxt-toolbox"
+          >https://github.com/netlify-templates/nuxt-toolbox</a
+        >! Happy coding!
+      </p>
     </div>
     <FeedbackForm />
     <JokeBlock />


### PR DESCRIPTION
## Summary

To make sure we communicate upfront what this website is, we wanted to add the title to the website. We do this already within our [Next.js toolbox](https://nextjs-toolbox.netlify.app) so keeping it consistent feels apt.

| Before | After |
| :---: | :---: |
| ![CleanShot 2022-05-05 at 11 18 13](https://user-images.githubusercontent.com/8431042/166956290-3de3cd75-5897-45bb-8ae3-7db6dad9d209.png) | ![CleanShot 2022-05-05 at 11 18 53](https://user-images.githubusercontent.com/8431042/166956403-35078dec-f5af-46c8-b238-b099cbd37f51.png) |

*Please ignore the viewed links 😆 
