### PR TITLE
Fix:updated location of plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,8 +21,7 @@
 
 [[plugins]]
   package = "netlify-plugin-cypress"
-  [plugins.inputs.postBuild]
-    enable = true
-
   [plugins.inputs]
     enable = false
+  [plugins.inputs.postBuild]
+    enable = true


### PR DESCRIPTION
# Summary
Updated plugin order  

Error: `Incorrect TOML configuration format: Key inputs is already used as table key`

We realized the order of the netlify.toml keys for the plugins matter and can cause errors while processing other keys. We identified that we lost our redirect rules.
 
Deploy Log: https://app.netlify.com/teams/template-team/builds/62b34079940ae621d0c377c4
